### PR TITLE
Fix practice category order

### DIFF
--- a/texas-hearing-institute/pages/ListeningSettings/tabs/ListeningBabble.tsx
+++ b/texas-hearing-institute/pages/ListeningSettings/tabs/ListeningBabble.tsx
@@ -4,8 +4,8 @@ import ButtonGroup from '../components/ButtonGroup';
 
 const headerText = 'Listening Babble';
 
-const buttons = ['Variegated Vowels', 'Manner', 'Place Cue', 'Voicing'];
-const routes = ['VariegatedVowels', 'Manner', 'PlaceCue', 'Voicing'];
+const buttons = ['Variegated Vowels', 'Manner', 'Voicing', 'Place'];
+const routes = ['VariegatedVowels', 'Manner', 'Voicing', 'Place'];
 
 export default function ListeningBabble() {
 	return (

--- a/texas-hearing-institute/pages/ListeningSettings/tabs/PlaceScreen.tsx
+++ b/texas-hearing-institute/pages/ListeningSettings/tabs/PlaceScreen.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import SettingsPage from '../components/SettingsPage';
 import { ConsonantFlower } from '../../../utils/Segment';
 
-export default function PlaceCueScreen() {
+export default function PlaceScreen() {
 	return (
 		<SettingsPage
-			title="Place Cue"
+			title="Place"
 			showVowelType
 			modeFlower={ConsonantFlower.Place}
 		/>

--- a/texas-hearing-institute/pages/PracticeNavigator.tsx
+++ b/texas-hearing-institute/pages/PracticeNavigator.tsx
@@ -4,7 +4,7 @@ import PracticeTab from './Home';
 import VarVowelsScreen from './ListeningSettings/tabs/VarVowelsScreen';
 import MannerScreen from './ListeningSettings/tabs/MannerScreen';
 import VoicingScreen from './ListeningSettings/tabs/VoicingScreen';
-import PlaceCueScreen from './ListeningSettings/tabs/PlaceCueScreen';
+import PlaceScreen from './ListeningSettings/tabs/PlaceScreen';
 import InitialConsonants from './SpeechSettings/tabs/InitialConsonants';
 import FinalConsonants from './SpeechSettings/tabs/FinalConsonants';
 import Vowels from './SpeechSettings/tabs/Vowels';
@@ -18,7 +18,7 @@ export type PracticeParamList = {
 	Vowels: undefined;
 	InitialConsonants: undefined;
 	FinalConsonants: undefined;
-	PlaceCue: undefined;
+	Place: undefined;
 	VariegatedVowels: undefined;
 	Manner: undefined;
 	Voicing: undefined;
@@ -56,10 +56,10 @@ export default function PracticeNavigator() {
 			<Stack.Screen name="Vowels" component={Vowels} />
 			<Stack.Screen name="InitialConsonants" component={InitialConsonants} />
 			<Stack.Screen name="FinalConsonants" component={FinalConsonants} />
-			<Stack.Screen name="PlaceCue" component={PlaceCueScreen} />
 			<Stack.Screen name="VariegatedVowels" component={VarVowelsScreen} />
 			<Stack.Screen name="Manner" component={MannerScreen} />
 			<Stack.Screen name="Voicing" component={VoicingScreen} />
+			<Stack.Screen name="Place" component={PlaceScreen} />
 			<Stack.Screen
 				name="ActivePractice"
 				component={Active}

--- a/texas-hearing-institute/pages/SpeechSettings/tabs/FinalConsonants.tsx
+++ b/texas-hearing-institute/pages/SpeechSettings/tabs/FinalConsonants.tsx
@@ -74,19 +74,19 @@ export default function FinalConsonants() {
 						<Text style={styles.subtitle}>SELECT MODE</Text>
 						<View>
 							<RadioButton<ConsonantFlower>
-								label={'Voicing'}
-								value={ConsonantFlower.Voice}
-								onPress={setModeFlower}
-								selectedRadio={modeFlower}
-							/>
-							<RadioButton<ConsonantFlower>
 								label={'Manner'}
 								value={ConsonantFlower.Manner}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}
 							/>
 							<RadioButton<ConsonantFlower>
-								label={'Place Cue'}
+								label={'Voicing'}
+								value={ConsonantFlower.Voice}
+								onPress={setModeFlower}
+								selectedRadio={modeFlower}
+							/>
+							<RadioButton<ConsonantFlower>
+								label={'Place'}
 								value={ConsonantFlower.Place}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}

--- a/texas-hearing-institute/pages/SpeechSettings/tabs/InitialConsonants.tsx
+++ b/texas-hearing-institute/pages/SpeechSettings/tabs/InitialConsonants.tsx
@@ -74,19 +74,19 @@ export default function InitialConsonants() {
 						<Text style={styles.subtitle}>SELECT MODE</Text>
 						<View>
 							<RadioButton<ConsonantFlower>
-								label={'Voicing'}
-								value={ConsonantFlower.Voice}
-								onPress={setModeFlower}
-								selectedRadio={modeFlower}
-							/>
-							<RadioButton<ConsonantFlower>
 								label={'Manner'}
 								value={ConsonantFlower.Manner}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}
 							/>
 							<RadioButton<ConsonantFlower>
-								label={'Place Cue'}
+								label={'Voicing'}
+								value={ConsonantFlower.Voice}
+								onPress={setModeFlower}
+								selectedRadio={modeFlower}
+							/>
+							<RadioButton<ConsonantFlower>
+								label={'Place'}
 								value={ConsonantFlower.Place}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}

--- a/texas-hearing-institute/pages/SpeechSettings/tabs/Vowels.tsx
+++ b/texas-hearing-institute/pages/SpeechSettings/tabs/Vowels.tsx
@@ -68,19 +68,19 @@ const Vowels = () => {
 						<Text style={styles.subtitle}>SELECT MODE</Text>
 						<View>
 							<RadioButton<ConsonantFlower>
-								label={'Voicing'}
-								value={ConsonantFlower.Voice}
-								onPress={setModeFlower}
-								selectedRadio={modeFlower}
-							/>
-							<RadioButton<ConsonantFlower>
 								label={'Manner'}
 								value={ConsonantFlower.Manner}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}
 							/>
 							<RadioButton<ConsonantFlower>
-								label={'Place Cue'}
+								label={'Voicing'}
+								value={ConsonantFlower.Voice}
+								onPress={setModeFlower}
+								selectedRadio={modeFlower}
+							/>
+							<RadioButton<ConsonantFlower>
+								label={'Place'}
 								value={ConsonantFlower.Place}
 								onPress={setModeFlower}
 								selectedRadio={modeFlower}


### PR DESCRIPTION
Amy from THI noted the category order should be "Manner", "Voicing", "Place", which corresponds with difficulty
Also removes "cue" from "Place Cue" because apparently this is redundant